### PR TITLE
minor improvement of readme and linux app

### DIFF
--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -26,7 +26,7 @@ int main(){
 
     create_participant();
 
-    uint32_t numer_of_tests = 10;
+    uint32_t number_of_tests = 10;
     const size_t test_data_size = 30; 
 
     bool received_response = false;
@@ -44,10 +44,10 @@ int main(){
 
     std::cout << "Got Reader match - starting tests..." << std::endl;
     
-    while(numer_of_tests > 0){
+    while(number_of_tests > 0){
         usleep(50000); //sleep 50 milliseconds
 
-        std::cout << "Conducting new Test..." << std::endl;
+        std::cout << "Conducting new Test: " << number_of_tests << std::endl;
 
         received_response = false;
         test_data.fill(15);
@@ -59,7 +59,7 @@ int main(){
             usleep(100);
         }
 
-        numer_of_tests--;
+        number_of_tests--;
     }
     
     return 0;

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@ This repository contains all components necessary to create a minimal working ex
 1. The first project in the `stm32/` directory is a STM32CubeIDE project which uses EmbeddedRTPS and is deployed to the STM32Nucleo-F767ZI.
 2. The second project in the `linux/` directory is a C++ project that uses eProsima FastRTPS for the Linux system. It can also be compiled and executed on macOS.
 
-When both of these projects are executed, the Linux system will send RTPS messages with test data to the STM32F407, to which the STM32F767ZI will then respond. This simple communication test is executed 10 times.
+When both of these projects are executed, the Linux system will send RTPS messages with test data to the STM32F767ZI, to which the STM32F767ZI will then respond. This simple communication test is executed 10 times.
 
 **[The main embeddedRTPS repository is located here.](https://github.com/embedded-software-laboratory/embeddedRTPS)**
 
@@ -56,7 +56,7 @@ This opens the menu to select the build configuration:
 
 The selected configuration is then compiled by STM32CubeIDE. 
 
-#### Flashing the STM32F407
+#### Flashing the STM32F767ZI
 The STM32 should now be connected to the Linux/macOS computer using a micro-USB cable. The cable should be plugged into a USB socket on your computer and into the __debugger__ side of the STM32 Nucleo board.
 
 The compiled configuration can then be flashed on to the STM32 in the following steps:

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # embeddedRTPS on STM32Nucleo-F767ZI
 This repository contains all components necessary to create a minimal working example of communication between an STM32F767ZI using embeddedRTPS and a Linux system using FastRTPS. This repository contains two projects:
-1. The first project in the `stm32` folder is a STM32CubeIDE project which uses EmbeddedRTPS and is deployed to the STM32Nucleo-F767ZI.
-2. The second project in the `linux` folder is a C++ project that uses eProsima FastRTPS for the Linux system.
+1. The first project in the `stm32/` directory is a STM32CubeIDE project which uses EmbeddedRTPS and is deployed to the STM32Nucleo-F767ZI.
+2. The second project in the `linux/` directory is a C++ project that uses eProsima FastRTPS for the Linux system. It can also be compiled and executed on macOS.
 
 When both of these projects are executed, the Linux system will send RTPS messages with test data to the STM32F407, to which the STM32F767ZI will then respond. This simple communication test is executed 10 times.
 
@@ -15,19 +15,19 @@ To compile the project for the STM32, install the following Software:
 
 ---
 
-### Linux/MacOS Project
+### Linux/macOS Project
 To compile the project for Linux, install the following Software:
 
 #### Ubuntu 18.04
 Packages to install using apt-get:
 ```bash
-sudo apt-get -y update && apt-get -y upgrade
+sudo apt-get -y update && sudo apt-get -y upgrade
 sudo apt-get install -y \
     software-properties-common \
     libboost-all-dev \
     libssl-dev \
     build-essential \
-    cmake \
+    cmake
 ```
 ## Compilation
 After installing the required dependencies, both projects can first cloned and compiled using the following instructions:
@@ -39,9 +39,11 @@ git clone --recursive https://github.com/embedded-software-laboratory/embeddedRT
 ### STM32F767ZI Project
 To compile and deploy the STM32 project, first open the STM32CubeIDE.
 ```
-File -> Open projects from File System -> Directory -> Select the stm32 Folder 
+File -> Open projects from File System -> Directory -> Select the stm32/ directory
 ```
 Then press finish to import the project into your local workspace.
+
+You need to prepare `rtps/include/rtps/config.h` file to compile the Project. The easiest way is to copy from `config_stm.h` in the same directory.
 
 Now select the project in the project explorer:
 ```
@@ -55,7 +57,7 @@ This opens the menu to select the build configuration:
 The selected configuration is then compiled by STM32CubeIDE. 
 
 #### Flashing the STM32F407
-The STM32 should now be connected to the linux computer using a micro-USB cable. The cable should be plugged into a USB socket on your computer and into the __debugger__ side of the STM32 Nucleo board.
+The STM32 should now be connected to the Linux/macOS computer using a micro-USB cable. The cable should be plugged into a USB socket on your computer and into the __debugger__ side of the STM32 Nucleo board.
 
 The compiled configuration can then be flashed on to the STM32 in the following steps:
 ```
@@ -69,14 +71,14 @@ It might now be necessary to select the target, in which case "STM32 Application
 
 ---
 
-### Linux project
+### Linux/macOS Project
 
-To compile the Linux project navigate to the linux folder. Then compile the CMakeLists project using the following commands:
+To compile the Linux/macOS project navigate to the `linux/` directory. Then compile the CMakeLists project using the following commands:
 ```bash
-cd linux \
-mkdir build \
-cd build \
-cmake -DTHIRDPARTY=ON .. \
+cd linux
+mkdir build
+cd build
+cmake -DTHIRDPARTY=ON ..
 make 
 ```
 
@@ -86,19 +88,20 @@ The resulting executable can then be found in the build directory and is called 
 
 After compiling both projects the communication between both devices can be tested. To conduct this test follow these steps:
 
-#### Setup on Linux
+#### Setup on Linux/macOS
 1. Connect the STM32 to your computer using a ethernet cable.
 2. Ensure all firewalls are disable. (probably an OSX issue)
 3. Manually assign an IP address (and subnet mask) to the STM32. <br>
    (for example: IP:192.168.0.1, subnet: 255.255.255.0) 
 4. (It may be necessary to disable other network connections, like wifi, if the chosen IP address is in your local network, necessary with the example adresses provided here.)
+5. (You can also communicate with the STM32 via a router. Network settings such as IP address are in `rtps/include/rtps/config.h` and `Src/lwip.c`.)
 
 #### Executing the Test
 
 1. Flash a configuration to the STM32 and run it.
 2. The debugger will halt on the first line of the main method, press either F8 or the Resume button.
 3. The STM32 should now wait for a subscriber match (to verify this flash the debug configuration and execute steps one and two, then halt the debugger after a couple of seconds after clicking resume in step 2, the debugger should halt on line 495).
-4. Execute the `embedded_rtps_test` executable in the linux/build folder.
+4. Execute the `embedded_rtps_test` executable in the `linux/build` directory.
 5. The executable will then send test data to the STM32 and the STM32 should respond to by returning other test data of the following form: <br>
 ``` 
 Received message from STM32 with len:10


### PR DESCRIPTION
- minor improvement on readme.md
  - unify terms (folder -> directory, MacOS -> macOS)
    - NOTE: I confirmed `linux/` can be operated on macOS
  - fix Linux commands
  - add explaination to prepare `rtps/include/rtps/config.h` to compile the STM32 project
  - add tips to set network environment
- print `number_of_tests` in linux app for debugging
  - We think it is better to observe the number of tests since communication may stop prematurely in our experience.
  - `numer_of_tests` seems to typo of `number_of_tests`