### PR TITLE
feat: enable `printf()` to display serial console

### DIFF
--- a/stm32/Core/Src/main.c
+++ b/stm32/Core/Src/main.c
@@ -72,6 +72,7 @@ void StartDefaultTask(void *argument);
 
 /* Private user code ---------------------------------------------------------*/
 /* USER CODE BEGIN 0 */
+#include <stdio.h>
 
 /* USER CODE END 0 */
 
@@ -107,6 +108,7 @@ int main(void)
   MX_USB_OTG_FS_PCD_Init();
   MX_USART6_UART_Init();
   /* USER CODE BEGIN 2 */
+  setbuf(stdout, NULL);
 
   /* USER CODE END 2 */
 
@@ -380,7 +382,11 @@ static void MX_GPIO_Init(void)
 }
 
 /* USER CODE BEGIN 4 */
-
+int _write(int file, char *ptr, int len)
+{
+  HAL_UART_Transmit(&huart3,(uint8_t *)ptr,len,10);
+  return len;
+}
 /* USER CODE END 4 */
 
 /* USER CODE BEGIN Header_StartDefaultTask */

--- a/stm32/Core/Src/rtps.cpp
+++ b/stm32/Core/Src/rtps.cpp
@@ -16,7 +16,7 @@ void setTrue(void* args){
 }
 
 void message_callback(void* callee, const rtps::ReaderCacheChange& cacheChange){
-	printf("Received data from Linux");
+	printf("Received data from Linux\r\n");
 }
 
 


### PR DESCRIPTION
I guess USART3 is enabled for serial output in this project, but it is not configured enough to display `printf()`. This PR adds some configurations to display the serial console. As a result, we can confirm the following serial output that the message was published (sent back) from `hello_world` in linux/. 

```
Received data from Linux
Received data from Linux
Received data from Linux
```

And also, we can also use LOG messages in embeddedRTPS (that is my motivation for this PR).